### PR TITLE
Add lock to avoid concurrency update to importer recordset report data

### DIFF
--- a/connector_importer/components/importer.py
+++ b/connector_importer/components/importer.py
@@ -342,8 +342,9 @@ class RecordImporter(Component):
                     raise err
                 continue
 
-        # update report
-        # self._do_report() # comment because we won't be able to run multiple import in same time
+        # added to prevent concurrency update issue that happens inside below do_update method for report_data
+        self.advisory_lock_or_retry(f"recordset_id-{self.recordset.id}_report_data")
+        self._do_report()
 
         # log chunk finished
         msg = " ".join(

--- a/connector_importer/components/importer.py
+++ b/connector_importer/components/importer.py
@@ -304,6 +304,9 @@ class RecordImporter(Component):
             logger.error(msg)
             return
 
+        # added to prevent concurrency update issue that happens inside below do_update method for report_data
+        self.advisory_lock_or_retry(f"{self.record.recordset_id}-report_data")
+
         self._init_importer(self.record.recordset_id)
         for line in self._record_lines():
             line = self.prepare_line(line)
@@ -342,9 +345,7 @@ class RecordImporter(Component):
                     raise err
                 continue
 
-        # added to prevent concurrency update issue that happens inside below do_update method for report_data
-        self.advisory_lock_or_retry(f"recordset_id-{self.recordset.id}_report_data")
-        self._do_report()
+        self._do_report()  # throw an error with big files if they cause of concurrency but we handled by above lock
 
         # log chunk finished
         msg = " ".join(


### PR DESCRIPTION
Before there was an error was happening due to concurrent update inside `_do_report()` method in the importer so the method was commented but we lost the skipped and error lines info from importer files.
But to get the info again and avoid the problem i remove the comment `_do_report` and added a lock to prevent concurrent update
https://data4altayyargroup.atlassian.net/browse/AYES-1500